### PR TITLE
Disable history scroll restoration and defer scroll reset

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,25 +10,43 @@
 	$: isHome = $page.url.pathname === '/';
   
         onMount(() => {
-          const runEnhancements = async () => {
-                await tick();
-                try {
-                        enhanceCodeBlocks();
-                        renderMath();
-                } catch (error) {
-                        console.error('Enhancement failure', error);
+                if ('scrollRestoration' in history) {
+                        history.scrollRestoration = 'manual';
                 }
-          };
 
-          runEnhancements().catch(() => {
-                /* handled in function */
-          });
+                const runEnhancements = async () => {
+                        await tick();
+                        try {
+                                enhanceCodeBlocks();
+                                renderMath();
+                        } catch (error) {
+                                console.error('Enhancement failure', error);
+                        }
+                };
 
-          afterNavigate(() => {
                 runEnhancements().catch(() => {
                         /* handled in function */
                 });
-          });
+
+                afterNavigate((navigation) => {
+                        runEnhancements().catch(() => {
+                                /* handled in function */
+                        });
+
+                        const toUrl = navigation.to?.url;
+                        if (!toUrl) {
+                                return;
+                        }
+
+                        const pathnameChanged = navigation.from?.url.pathname !== toUrl.pathname;
+                        const hasHash = toUrl.hash.length > 0;
+
+                        if (pathnameChanged && !hasHash) {
+                                requestAnimationFrame(() => {
+                                        window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+                                });
+                        }
+                });
         });
   </script>
 


### PR DESCRIPTION
## Summary
- observed that the browser preserved the previous scroll position from the long home page during client-side routing, so post views opened already scrolled to the footer until the user refreshed
- set `history.scrollRestoration` to `manual` when the root layout mounts so SPA navigations no longer reuse the prior position
- defer the explicit `window.scrollTo` call to the next animation frame on path changes without hash fragments so the viewport reliably resets to the top before enhancements run

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d456e1aa648328a44797d4133b735e